### PR TITLE
Fix crash with Inventory Tweaks

### DIFF
--- a/src/main/java/com/rolandoislas/multihotbar/asm/transformer/Transformer.java
+++ b/src/main/java/com/rolandoislas/multihotbar/asm/transformer/Transformer.java
@@ -73,8 +73,6 @@ public class Transformer implements IClassTransformer {
         if (doesAnyStringEqual(className, name, transformedName)) {
             ClassNode classNode = byteArrayToClassNode(basicClass);
             try {
-                transformFieldToExtendedHotbar("HOTBAR_SIZE", "I",
-                        "", "", classNode);
                 transformFieldToExtendedHotbar("INVENTORY_HOTBAR_SIZE", "I",
                         "", "", classNode);
             }


### PR DESCRIPTION
The HOTBAR_SIZE constant does not exist in the latest 1.7.10 version of inventory tweaks, trying to transform it causes a crash.